### PR TITLE
Fix an encoding problem

### DIFF
--- a/src/main/java/com/welovecoding/nbeditorconfig/io/writer/StyledDocumentWriter.java
+++ b/src/main/java/com/welovecoding/nbeditorconfig/io/writer/StyledDocumentWriter.java
@@ -11,6 +11,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.Reader;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -135,7 +136,9 @@ public class StyledDocumentWriter {
               LOG.log(Level.INFO, "Write to \"document\": {0}", cookie.getDocument());
 
               // Read input stream into the document (which is a "write" operation)
-              kit.read(is, cookie.getDocument(), 0);
+              try (Reader reader = new InputStreamReader(is, info.getCharset())) {
+                kit.read(reader, cookie.getDocument(), 0);
+              }
               cookie.saveDocument();
 
               info.getFileObject().setAttribute(ENCODING_SETTING, info.getCharset().name());

--- a/src/main/java/com/welovecoding/nbeditorconfig/processor/EditorConfigProcessor.java
+++ b/src/main/java/com/welovecoding/nbeditorconfig/processor/EditorConfigProcessor.java
@@ -13,12 +13,14 @@ import com.welovecoding.nbeditorconfig.processor.operation.TabWidthOperation;
 import com.welovecoding.nbeditorconfig.processor.operation.TrimTrailingWhiteSpaceOperation;
 import com.welovecoding.nbeditorconfig.processor.operation.tobedone.CharsetOperation;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 import org.netbeans.api.project.Project;
+import org.netbeans.api.queries.FileEncodingQuery;
 import org.netbeans.modules.editor.indent.spi.CodeStylePreferences;
 import org.openide.cookies.EditorCookie;
 import org.openide.filesystems.FileObject;
@@ -117,9 +119,10 @@ public class EditorConfigProcessor {
     FileObject primaryFile = dataObject.getPrimaryFile();
     StringBuilder content;
 
+    MappedCharset mappedCharset = config.getCharset();
+    Charset defaultCharset = FileEncodingQuery.getEncoding(primaryFile);
     try {
-      MappedCharset mc = config.getCharset();
-      String charset = mc != null ? mc.getCharset().name() : StandardCharsets.UTF_8.name();
+      String charset = mappedCharset != null ? mappedCharset.getCharset().name() : defaultCharset.name();
       content = new StringBuilder(primaryFile.asText(charset));
     } catch (IOException ex) {
       LOG.log(Level.WARNING, "Failed to get the text of the file");
@@ -138,15 +141,13 @@ public class EditorConfigProcessor {
     info.setCookie(cookie);
 
     // 1. "charset"
-    MappedCharset mappedCharset = config.getCharset();
-
     if (mappedCharset != null) {
       logOperation(EditorConfigConstant.CHARSET, mappedCharset.getName());
       boolean changedCharset = new CharsetOperation().run(dataObject, mappedCharset);
       fileChangeNeeded = fileChangeNeeded || changedCharset;
       info.setCharset(mappedCharset.getCharset());
     } else {
-      info.setCharset(StandardCharsets.UTF_8);
+      info.setCharset(defaultCharset);
     }
 
     // 2. "end_of_line"

--- a/src/main/java/com/welovecoding/nbeditorconfig/processor/EditorConfigProcessor.java
+++ b/src/main/java/com/welovecoding/nbeditorconfig/processor/EditorConfigProcessor.java
@@ -194,11 +194,6 @@ public class EditorConfigProcessor {
       fileChangeNeeded = fileChangeNeeded || trimmedWhiteSpaces;
     }
 
-    if (mappedCharset != null) {
-    } else {
-      info.setCharset(StandardCharsets.UTF_8);
-    }
-
     info.setFileChangeNeeded(fileChangeNeeded);
     info.setStyleFlushNeeded(styleFlushNeeded);
 

--- a/src/main/java/com/welovecoding/nbeditorconfig/processor/EditorConfigProcessor.java
+++ b/src/main/java/com/welovecoding/nbeditorconfig/processor/EditorConfigProcessor.java
@@ -118,7 +118,9 @@ public class EditorConfigProcessor {
     StringBuilder content;
 
     try {
-      content = new StringBuilder(primaryFile.asText());
+      MappedCharset mc = config.getCharset();
+      String charset = mc != null ? mc.getCharset().name() : StandardCharsets.UTF_8.name();
+      content = new StringBuilder(primaryFile.asText(charset));
     } catch (IOException ex) {
       LOG.log(Level.WARNING, "Failed to get the text of the file");
       content = new StringBuilder("");


### PR DESCRIPTION
PR for #75 

An encoding has to be set when a file content is read because default system one may be used.

`UTF-8` is set to the FileInfo when the MappedCharset is null. So, I used `UTF-8` as default encoding when the content is got.

Thanks.