### PR TITLE
Fix of welovecoding/editorconfig-netbeans#115

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,11 @@ sudo: false
 # http://docs.travis-ci.com/user/languages/java/
 language: java
 
-matrix:
-    include:
-      - jdk: openjdk8
-      - jdk: openjdk9
-      - jdk: openjdk10
-      - jdk: openjdk11
-      - jdk: oraclejdk8
-      - jdk: oraclejdk10
-    allow_failures:
-      - jdk: openjdk-ea
-      - jdk: oraclejdk-ea
+jdk:
+  - openjdk8
+  - oraclejdk8
+  - oraclejdk9
+  - oraclejdk11
 
 #Cache downloaded Maven artifacts between builds
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ jdk:
   - openjdk8
   - oraclejdk8
   - oraclejdk9
-  - oraclejdk11
+#  - oraclejdk10
+#  - oraclejdk11
 
 #Cache downloaded Maven artifacts between builds
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,27 @@
+%YAML 1.1
+
 # http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
 
 # http://docs.travis-ci.com/user/languages/java/
 language: java
 
-jdk:
-  - oraclejdk8
+matrix:
+    include:
+      - jdk:
+        - openjdk8
+        - openjdk9
+        - openjdk10
+        - openjdk11
+        - oraclejdk8
+        - oraclejdk10
+    allow_failure:
+      - jdk:
+        - openjdk-ea
+        - oraclejdk-ea
+    before_install:
+      - rm "${JAVA_HOME}/lib/security/cacerts"
+      - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
   
 #Cache downloaded Maven artifacts between builds
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,6 @@ matrix:
       - jdk: openjdk-ea
       - jdk: oraclejdk-ea
 
-before_install:
-      - rm "${JAVA_HOME}/lib/security/cacerts"
-      - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
-  
 #Cache downloaded Maven artifacts between builds
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-%YAML 1.1
-
 # http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
 
@@ -8,18 +6,17 @@ language: java
 
 matrix:
     include:
-      - jdk:
-        - openjdk8
-        - openjdk9
-        - openjdk10
-        - openjdk11
-        - oraclejdk8
-        - oraclejdk10
-    allow_failure:
-      - jdk:
-        - openjdk-ea
-        - oraclejdk-ea
-    before_install:
+      - jdk: openjdk8
+      - jdk: openjdk9
+      - jdk: openjdk10
+      - jdk: openjdk11
+      - jdk: oraclejdk8
+      - jdk: oraclejdk10
+    allow_failures:
+      - jdk: openjdk-ea
+      - jdk: oraclejdk-ea
+
+before_install:
       - rm "${JAVA_HOME}/lib/security/cacerts"
       - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
   

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,9 @@
     <nbm.signing.keystorealias></nbm.signing.keystorealias>
     <nbm.signing.keystorepassword></nbm.signing.keystorepassword>
     <nbm.skip>false</nbm.skip>
+    
+    <!-- Set to a custom path of some local JDK to use it to execite nbm:run-ide -->
+    <nbm.jdkHome>${env.JAVA_HOME}</nbm.jdkHome>
   </properties>
 
   <repositories>
@@ -57,6 +60,12 @@
     <dependency>
       <groupId>org.netbeans.api</groupId>
       <artifactId>org-netbeans-api-annotations-common</artifactId>
+      <version>${netbeans.api.version}</version>
+    </dependency>
+        
+    <dependency>
+      <groupId>org.netbeans.api</groupId>
+      <artifactId>org-netbeans-modules-java-platform</artifactId>
       <version>${netbeans.api.version}</version>
     </dependency>
 
@@ -254,7 +263,7 @@
     <dependency>
       <groupId>org.netbeans.api</groupId>
       <artifactId>org-netbeans-modules-editor-util</artifactId>
-      <version>RELEASE82</version>
+      <version>${netbeans.api.version}</version>
     </dependency>
   </dependencies>
 
@@ -278,6 +287,8 @@
           <publicPackages>
             <publicPackage>com.welovecoding.netbeans.plugin.editorconfig</publicPackage>
           </publicPackages>
+          <additionalArguments>--jdkhome ${nbm.jdkHome}</additionalArguments>
+          <debugAdditionalArguments></debugAdditionalArguments>
         </configuration>
       </plugin>
       <plugin>
@@ -300,6 +311,29 @@
           </execution>
         </executions>
       </plugin>
+      
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-toolchains-plugin</artifactId>
+        <version>1.1</version>
+        <executions>
+          <execution>
+            <id>verify-jdk</id>
+            <goals>
+              <goal>toolchain</goal>
+            </goals>
+            <configuration>
+              <toolchains>
+                <jdk>
+                  <version>[1.7.0,)</version>
+                </jdk>
+              </toolchains>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      
+      
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -309,6 +343,7 @@
           <target>1.7</target>
           <showWarnings>true</showWarnings>
           <optimize>true</optimize>
+          <showDeprecation>true</showDeprecation>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -311,29 +311,7 @@
           </execution>
         </executions>
       </plugin>
-      
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-toolchains-plugin</artifactId>
-        <version>1.1</version>
-        <executions>
-          <execution>
-            <id>verify-jdk</id>
-            <goals>
-              <goal>toolchain</goal>
-            </goals>
-            <configuration>
-              <toolchains>
-                <jdk>
-                  <version>[1.7.0,)</version>
-                </jdk>
-              </toolchains>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      
-      
+       
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Remove old regex based JVM version detection from Installer class
Add dependency for the Netbeans java-platform module
Add support for running IDE with specified JDK via nbm:run-ide
Add "nbm.jdkHome" POM property for specifying path to nbm:run-ide JDK
Add maven-toolchains-plugin execution to verify compilation JDK
Modify maven-compiler plugin to show deprecated method calls
Fix Netbeans editor-util dependency to track Netbeans API version
Add basic java.util.Logging support to Installer class

Signed-off-by: Emily Mabrey <3370875+emabrey@users.noreply.github.com>