### PR TITLE
Merge of various enhancements/fixes from emabrey

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,18 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.takari.maven</groupId>
+    <artifactId>takari-smart-builder</artifactId>
+    <version>0.6.1</version>
+  </extension>  
+  <extension>
+    <groupId>io.takari.aether</groupId>
+    <artifactId>takari-local-repository</artifactId>
+    <version>0.11.2</version>
+  </extension>
+  <extension>
+    <groupId>io.takari.aether</groupId>
+    <artifactId>aether-connector-okhttp</artifactId>
+    <version>0.17.4</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,1 @@
--T 1C --fail-fast --strict-checksums
+--fail-fast --strict-checksums

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,1 @@
---fail-fast --strict-checksums
+-T 1C --fail-fast --strict-checksums

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,8 @@ jdk:
   - openjdk9
   - openjdk10
   - openjdk11
-  - oraclejdk7
   - oraclejdk8
   - oraclejdk9 
-  - oraclejdk10
   - oraclejdk11
 
 #Cache downloaded Maven artifacts between builds

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,16 @@ sudo: false
 language: java
 
 jdk:
+  - openjdk7
   - openjdk8
+  - openjdk9
+  - openjdk10
+  - openjdk11
+  - oraclejdk7
   - oraclejdk8
-  - oraclejdk9
-#  - oraclejdk10
-#  - oraclejdk11
+  - oraclejdk9 
+  - oraclejdk10
+  - oraclejdk11
 
 #Cache downloaded Maven artifacts between builds
 cache:

--- a/pom.xml
+++ b/pom.xml
@@ -267,8 +267,36 @@
     </dependency>
   </dependencies>
 
-  <build>
+  <profiles>
+    <profile>
+      <id>jigsaw-annotation-fix</id>
+      <activation>
+        <jdk>[1.9.0,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+          <version>1.3.2</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
+  <build>    
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+          <showWarnings>true</showWarnings>
+          <optimize>true</optimize>
+          <showDeprecation>true</showDeprecation>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>nbm-maven-plugin</artifactId>
@@ -312,18 +340,7 @@
         </executions>
       </plugin>
        
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.0</version>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-          <showWarnings>true</showWarnings>
-          <optimize>true</optimize>
-          <showDeprecation>true</showDeprecation>
-        </configuration>
-      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>

--- a/src/main/resources/com/welovecoding/nbeditorconfig/listener/Bundle.properties
+++ b/src/main/resources/com/welovecoding/nbeditorconfig/listener/Bundle.properties
@@ -1,2 +1,2 @@
-wlc-nbeditorconfig-version-error-title=Invalid Java Version for EditorConfig Plugin
-wlc-nbeditorconfig-version-error-message=The EditorConfig Plugin needs at least Java 8 to work. Please consider to update to Java 8.
+wlc-nbeditorconfig-version-error-title=Invalid Java Version - EditorConfig Plugin
+wlc-nbeditorconfig-version-error-message=The EditorConfig Plugin needs Java 1.7 or greater to work. Please consider updating to a compatible Java version.


### PR DESCRIPTION
- Fix for failed Travis-CI builds. Now _additionally_ supports: `openjdk7`,  `openjdk9` , `openjdk10` , ` openjdk11` , `oraclejdk9` and `oraclejdk11`
- Enhance Maven builds to utilize "better" Takari extensions for improvements to M2 repository access, faster HTTP downloads and smarter build graph generation
- Fix bundled error message for bad JVM versions as specified in welovecoding/editorconfig-netbeans#81
- Update `maven-compiler-plugin` to version 3.8.0